### PR TITLE
Add ability to mute detectors for a specific duration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ run: build
 	  --region us-west-2 \
 		--cloudwatchregion us-west-1 \
 	  --workername `hostname` \
-	  --cmd ./bin/$(EXECUTABLE) -task=stale
+	  --cmd ./bin/$(EXECUTABLE)
 
 
 install_deps: golang-dep-vendor-deps

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ run: build
 	  --region us-west-2 \
 		--cloudwatchregion us-west-1 \
 	  --workername `hostname` \
-	  --cmd ./bin/$(EXECUTABLE)
+	  --cmd ./bin/$(EXECUTABLE) -task=stale
 
 
 install_deps: golang-dep-vendor-deps

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # signalfx-janitor
 
-Cleans up stale alerts in SignalFX
+Cleans up stale alerts in SignalFX,
+Alternatively mutes noisy alerts for a specified amount of time.
 
 Owned by `eng-infra`.
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/Clever/configure"
 )
 
 const baseURL = "https://api.signalfx.com/"
@@ -25,16 +28,45 @@ func envOrDie(s string) string {
 }
 
 func main() {
-	incidents, err := GetV1Incidents()
-	if err != nil {
-		log.Fatal("error looking up incidents:", err.Error())
+	var flags struct {
+		Task     string `config:"task,required"`
+		Detector string `config:"detector"`
+		Duration string `config:"duration"`
 	}
 
-	log.Printf("Found %d incidents\n", len(incidents))
+	if err := configure.Configure(&flags); err != nil {
+		log.Fatalf("Configure parse error: " + err.Error())
+	}
 
-	err = resolveIncidents(incidents)
-	if err != nil {
-		log.Fatal("error resolving incidents:", err.Error())
+	switch flags.Task {
+	case "stale":
+		incidents, err := GetV1Incidents()
+		if err != nil {
+			log.Fatal("error looking up incidents:", err.Error())
+		}
+
+		log.Printf("Found %d incidents\n", len(incidents))
+
+		err = resolveIncidents(incidents)
+		if err != nil {
+			log.Fatal("error resolving incidents:", err.Error())
+		}
+	case "mute":
+		if flags.Detector == "" || flags.Duration == "" {
+			log.Fatal("mute requires both detector and duration flags")
+		}
+
+		duration, err := time.ParseDuration(flags.Duration)
+		if err != nil {
+			log.Fatal("error looking up incidents:", err.Error())
+		}
+
+		err = muteDetector(flags.Detector, duration)
+		if err != nil {
+			log.Fatal("error muting detector:", err.Error())
+		}
+	default:
+		log.Fatal("unexpected task:", flags.Task)
 	}
 }
 
@@ -158,6 +190,48 @@ func clearIncident(incidentID string) error {
 		}
 		log.Println("error:", string(body))
 		return fmt.Errorf("Error clearing incident %s, got StatusCode %d", incidentID, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// muteDetector works for V1 and V2 detectors
+// https://developers.signalfx.com/reference#alertmuting-1
+func muteDetector(detectorID string, silence time.Duration) error {
+	url := baseURL + "v2/alertmuting"
+
+	now := time.Now()
+	round := int64(time.Millisecond) / int64(time.Nanosecond)
+	args := map[string]interface{}{
+		"filters":     []map[string]string{{"property": "sf_detectorId", "propertyValue": detectorID}},
+		"startTime":   now.UnixNano() / round,
+		"stopTime":    now.Add(silence).UnixNano() / round,
+		"description": "Muted by signalfx-janitor",
+	}
+	data, _ := json.Marshal(args)
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-SF-TOKEN", sfxToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		log.Println("error:", string(body))
+		return fmt.Errorf("Error muting incident %s, got StatusCode %d", detectorID, resp.StatusCode)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -28,10 +28,12 @@ func envOrDie(s string) string {
 }
 
 func main() {
-	var flags struct {
+	flags := struct {
 		Task     string `config:"task,required"`
 		Detector string `config:"detector"`
 		Duration string `config:"duration"`
+	}{
+		Task: "stale",
 	}
 
 	if err := configure.Configure(&flags); err != nil {


### PR DESCRIPTION
Useful for overnight silencing.

Note that I've added a -task flag so we can differentiate from the previous functionality.
I'll update the cron tasks before deploying.


Tested this out manually on one of our problematic detectors, and was able to create mutes:
![image](https://user-images.githubusercontent.com/11928921/38647945-b05d32c2-3da3-11e8-8562-6fa50ac18403.png)
And confirmed that they clear themselves out after the time expires. Hooray!