### PR TITLE
migrate to noHomepod

### DIFF
--- a/launch/signalfx-janitor.yml
+++ b/launch/signalfx-janitor.yml
@@ -19,8 +19,4 @@ autoscaling:
   metric_target: 70
   max_count: 1
 pod_config:
-  dev:
-    migrationState: podOnly
   group: us-west-1
-  prod:
-    migrationState: podOnly


### PR DESCRIPTION
Migrate workers to noHomepod. `ark scale` is fixed and for the relevant workers, they are scaled to the previous value
