### PR TITLE
Set count to exactly 1.

### DIFF
--- a/launch/signalfx-janitor.yml
+++ b/launch/signalfx-janitor.yml
@@ -15,8 +15,7 @@ shepherds:
 expose: []
 team: eng-infra
 autoscaling:
-  metric: active-percent
-  metric_target: 70
   max_count: 1
+  min_count: 1
 pod_config:
   group: us-west-1


### PR DESCRIPTION
Currently deployments are failing with error an error creating the ServiceScalingTarget resource
from [CloudFormation](https://us-west-1.console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/events?filteringStatus=active&filteringText=signalfx-janitor&viewNested=true&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aus-west-1%3A589690932525%3Astack%2Fproduction--signalfx-janitor--a6127c9c%2Fbcde5c30-9181-11eb-959a-06b5fab125f1):

```
Maximum capacity cannot be less than minimum capacity (Service: AWSApplicationAutoScaling; Status
Code: 400; Error Code: ValidationException; Request ID: 16e78d89-5254-44cc-8818-93f7b4b48f4b; Proxy:
null)
```

I think this will fix it?