### PR TITLE
[automated] Upgrade to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/signalfx-janitor
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: circleci/golang:1.16-stretch
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG := github.com/Clever/signalfx-janitor
 PKGS = $(shell go list ./... | grep -v "vendor/"  | grep -v /vendor)
 EXECUTABLE = $(shell basename $(PKG))
 SFNCLI_VERSION := latest
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.16))
 
 all: test build
 


### PR DESCRIPTION
This PR migrates to Go 1.16.

If the build passes, no action is required by you, infra will merge and deploy this. For any questions, reach out to @taylor-sutton (Slack `taylor`) or #oncall-infra.
